### PR TITLE
add --motor-namespace argument in rqt_pr2_dashboard

### DIFF
--- a/scripts/rqt_pr2_dashboard
+++ b/scripts/rqt_pr2_dashboard
@@ -2,12 +2,9 @@
 
 import sys
 
-import roslib
-
-pkg = 'rqt_pr2_dashboard'
-roslib.load_manifest(pkg)
-
 from rqt_gui.main import Main
+from rqt_pr2_dashboard.pr2_dashboard import PR2Dashboard
 
+plugin = 'rqt_pr2_dashboard.pr2_dashboard.PR2Dashboard'
 main = Main()
-sys.exit(main.main(sys.argv, standalone=pkg))
+sys.exit(main.main(standalone=plugin, plugin_argument_provider=PR2Dashboard.add_arguments))


### PR DESCRIPTION
I add `--motor-namespace` arguments.
With this PR, we can customize motor halt and cancel namespace as follow:

```bash
rosrun rqt_pr2_dashboard rqt_pr2_dashboard --motor-namespace pr2_reset_motors
```

related: https://github.com/jsk-ros-pkg/jsk_robot/pull/1258

this PR follow arguments passing way in `rqt_plot`.
https://github.com/ros-visualization/rqt_plot/blob/master/scripts/rqt_plot#L10
https://github.com/ros-visualization/rqt_plot/blob/master/src/rqt_plot/plot.py#L107-L114
https://github.com/ros-visualization/rqt_plot/blob/master/src/rqt_plot/plot.py#L54
https://github.com/ros-visualization/rqt_plot/blob/master/src/rqt_plot/plot.py#L70-L105